### PR TITLE
Fix infinite loop after succesful install

### DIFF
--- a/SimWinGamePad/SimGamePad.cs
+++ b/SimWinGamePad/SimGamePad.cs
@@ -47,6 +47,7 @@ namespace SimWinInput
                 try
                 {
                     bus = new ScpBus();
+                    retryInit = false;
                 }
                 catch (IOException)
                 {


### PR DESCRIPTION
First of all: great package! Very helpful +1

On first initialization I allowed the driver to be installed. Which means [retryInit = true](https://github.com/DavidRieman/SimWinInput/blob/ba289ede184b2a5a1237d596d5e34e805d18c64b/SimWinGamePad/SimGamePad.cs#L59)

After that the program loops infinitely retrying (and being succesful) in [initializing the ScpBus](
https://github.com/DavidRieman/SimWinInput/blob/ba289ede184b2a5a1237d596d5e34e805d18c64b/SimWinGamePad/SimGamePad.cs#L49).

Fix is simply adding `retryInit = false` after initializing the ScpBus.